### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Este proyecto demuestra cómo crear un servidor MCP (Model Context Protocol) personalizado con una herramienta de clima e integrarlo con OpenAI usando Cloudflare Tunnel.
 
+<a href="https://glama.ai/mcp/servers/@Dagudelot/mcp-server-openai-sdk">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Dagudelot/mcp-server-openai-sdk/badge" alt="Server with OpenAI Integration MCP server" />
+</a>
+
 ## 🚀 Características
 
 - **Servidor MCP personalizado** con herramienta de clima


### PR DESCRIPTION
This PR adds a badge for the [MCP Server with OpenAI Integration](https://glama.ai/mcp/servers/@Dagudelot/mcp-server-openai-sdk) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Dagudelot/mcp-server-openai-sdk">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Dagudelot/mcp-server-openai-sdk/badge" alt="Server with OpenAI Integration MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.